### PR TITLE
irc_handler: Account for joins with #

### DIFF
--- a/irc_handler.py
+++ b/irc_handler.py
@@ -114,6 +114,8 @@ class IRCHandler(object):
       for channel in chanid.split(','):
         self.irc_join(channel)
       return
+    if chanid.startswith('#') and chanid[1:].isdecimal():
+        chanid = chanid[1:]
     if chanid in self.channels or chanid.startswith('#'):
       return
 


### PR DESCRIPTION
Some IRC clients like [thelounge](https://github.com/thelounge/thelounge) only send /joins with #s prepended. This PR accounts for such cases.

This code wasn't tested on Python2 (I believe it needs .isdigit() instead of .isdecimal(), but I'm not sure), however, considering how python2 is EOL, I don't think that's That Big Of A Problem.


Note: This doesn't account for the #channel1,channel2,channel3 etc thing